### PR TITLE
Use setnames(), not names<-

### DIFF
--- a/R/getDTeval.R
+++ b/R/getDTeval.R
@@ -131,7 +131,7 @@ getDTeval <- function(the.statement, return.as = "result", coding.statements.as 
 
   the.result <- eval(expr = parse(text = the.statement), envir = envir)
 
-  names(the.result) <- gsub(pattern = "`", replacement = "", x = names(the.result))
+  setnames(the.result, gsub(pattern = "`", replacement = "", x = names(the.result)))
 
   if(return.as == value.all){
     if(coding.statements.as == value.expression){

--- a/R/getDTeval.R
+++ b/R/getDTeval.R
@@ -131,7 +131,8 @@ getDTeval <- function(the.statement, return.as = "result", coding.statements.as 
 
   the.result <- eval(expr = parse(text = the.statement), envir = envir)
 
-  setnames(the.result, gsub(pattern = "`", replacement = "", x = names(the.result)))
+  new.names <- gsub(pattern = "`", replacement = "", x = names(the.result))
+  if (is.data.table(the.result)) setnames(the.result, new.names) else names(the.result) <- new.names
 
   if(return.as == value.all){
     if(coding.statements.as == value.expression){


### PR DESCRIPTION
See https://github.com/Rdatatable/data.table/issues/5127. `names<-.data.table` is discouraged; use `setnames()` whenever you know the input object is a data.table.

PS it would be advisable to include this GitHub repo in the package DESCRIPTION to make it easier to find from CRAN.